### PR TITLE
Add fields option

### DIFF
--- a/lib/omniauth/strategies/instagram.rb
+++ b/lib/omniauth/strategies/instagram.rb
@@ -30,7 +30,7 @@ module OmniAuth
       info { raw_info }
       
       def fields
-        fields ||= options[:fields] || 'account_type,id,media_count,username'
+        @fields ||= options[:fields] || 'account_type,id,media_count,username'
       end
 
       def raw_info

--- a/lib/omniauth/strategies/instagram.rb
+++ b/lib/omniauth/strategies/instagram.rb
@@ -28,10 +28,13 @@ module OmniAuth
       uid { raw_info['id'] }
 
       info { raw_info }
+      
+      def fields
+        fields ||= options[:fields] || 'account_type,id,media_count,username'
+      end
 
       def raw_info
         endpoint = '/me'
-        fields = 'account_type,id,media_count,username'
         @raw_info ||= access_token.get("#{endpoint}?fields=#{fields}").parsed
       end
 


### PR DESCRIPTION
It's necessary for cases when your app doesn't have user_media permission for fetching media_count field.